### PR TITLE
Amazon Linux 2 support for awslogs daemon

### DIFF
--- a/bastion_bootstrap.sh
+++ b/bastion_bootstrap.sh
@@ -172,8 +172,13 @@ EOF
     sed -i.back "s/$TMPREGION/region = $Region/g" /etc/awslogs/awscli.conf
 
     #Restart awslogs service
-    service awslogs restart
-    chkconfig awslogs on
+    VERSION=`cat /etc/os-release | grep '^VERSION=' |  tr -d \" | sed 's/\n//g' | sed 's/VERSION=//g'`
+    if [ "$VERSION" == "2" ]; then
+      systemctl restart awslogsd
+    else
+      service awslogs restart
+      chkconfig awslogs on
+    fi
 
     #Run security updates
 cat <<'EOF' >> ~/mycron


### PR DESCRIPTION
*Description of changes:*

awslogs daemon has changed name in Amazon Linux 2. Migrated to systemd command set along the way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.