### PR TITLE
Added missing parameter according to #10

### DIFF
--- a/guardduty-tester.template
+++ b/guardduty-tester.template
@@ -641,7 +641,8 @@
                     },
                     {
                         "Key" : "CreatedBy",
-                        "Value" : "GuardDuty Test Script"
+                        "Value" : "GuardDuty Test Script",
+                        "PropagateAtLaunch": "true"
                     }
                 ]
             },


### PR DESCRIPTION
*Issue [#10](https://github.com/awslabs/amazon-guardduty-tester/issues/10)*

*Description of changes:*
Added required, missing parameter **_PropagateAtLaunch_** at 

> Resources.BastionAutoScalingGroup.Properties.Tags


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
