### PR TITLE
Fix finding name for DNS Exfiltration

### DIFF
--- a/guardduty_tester.sh
+++ b/guardduty_tester.sh
@@ -128,7 +128,7 @@ echo 'Finding Type : CryptoCurrency:EC2/BitcoinTool.B!DNS'
 echo
 echo 'Test 5: DNS Exfiltration'
 echo 'Expected Finding: EC2 instance ' $RED_TEAM_INSTANCE ' is attempting to query domain names that resemble exfiltrated data'
-echo 'Finding Type : Backdoor:EC2/DNSDataExfiltration'
+echo 'Finding Type : Trojan:EC2/DNSDataExfiltration'
 echo
 echo 'Test 6: C&C Activity'
 echo 'Expected Finding: EC2 instance ' $RED_TEAM_INSTANCE ' is querying a domain name associated with a known Command & Control server. '


### PR DESCRIPTION
The finding generated for DNS exfiltration is called Trojan:EC2/DNSDataExfiltration per - https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_finding-types-ec2.html#trojan-ec2-dnsdataexfiltration

*Description of changes:*
Fixes the log print to indicate the right finding type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
