### PR TITLE
Updated ProxyCommand method and removed use of NetCat

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Host tester</br>
 &nbsp;&nbsp;&nbsp;&nbsp;HostName {Local IP Address of RedTeam Instance}</br>
 &nbsp;&nbsp;&nbsp;&nbsp;User ec2-user</br>
 &nbsp;&nbsp;&nbsp;&nbsp;IdentityFile ~/.ssh/{your-ssh-key.pem</br>
-&nbsp;&nbsp;&nbsp;&nbsp;ProxyCommand ssh bastion nc %h %p</br>
+&nbsp;&nbsp;&nbsp;&nbsp;ProxyCommand ssh -W %h:%p bastion</br>
 &nbsp;&nbsp;&nbsp;&nbsp;ServerAliveInterval 240</br>
 </br>
 You would simply call $ ssh tester to login at that point. </br>


### PR DESCRIPTION
*Issue #, if available: 19
*Description of changes: Updated ProxyCommand method in Step 2 of README.md. Current method using ProxyCommand with NetCat no longer works with bastion host. Updated to use -W switch available in OpenSSH.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
