### PR TITLE
Adding test for AttackSequence:S3/CompromisedData

### DIFF
--- a/lib/common/compute/ecs/driver-cluster.ts
+++ b/lib/common/compute/ecs/driver-cluster.ts
@@ -44,6 +44,7 @@ export interface EcsProps extends Ec2Props {
   ecsCluster: string;
   stepFuncArn: string;
   emptyBucketName: string;
+  attackBucketName: string;
   fargateTaskFamily: string;
   ec2TaskFamily: string;
 }
@@ -183,6 +184,7 @@ export class TestDriverEcsCluster extends Construct {
       `echo "WINDOWS_INSTANCE = '${props.windowsInstance}'" >> ${homeDir}/py_tester/tester_vars.py`,
       `echo "S3_BUCKET_NAME = '${props.bucketName}'" >> ${homeDir}/py_tester/tester_vars.py`,
       `echo "EMPTY_BUCKET_NAME = '${props.emptyBucketName}'" >> ${homeDir}/py_tester/tester_vars.py`,
+      `echo "ATTACK_BUCKET_NAME = '${props.attackBucketName}'" >> ${homeDir}/py_tester/tester_vars.py`,
       `echo "TEMP_ROLE_ARN = '${props.tempRole}'" >> ${homeDir}/py_tester/tester_vars.py`,
       `echo "REGION = '${region}'" >> ${homeDir}/py_tester/tester_vars.py`,
       `echo "ACCNT_ID = '${props.accountId}'" >> ${homeDir}/py_tester/tester_vars.py`,

--- a/lib/common/testResources/definitions.json
+++ b/lib/common/testResources/definitions.json
@@ -1022,6 +1022,16 @@
             "local": "false"
         },
         {
+            "resource": "attack-sequence",
+            "tactic": "attack-sequence",
+            "findingType": "AttackSequence:S3/CompromisedData",
+            "alias": "attack/S3CompromisedData.sh",
+            "description": "echo \"Test #$TEST_NUM - Attack Sequence S3 Compromised Data\"",
+            "expectedFinding": "\"Test #$TEST_NUM - Attack Sequence S3 Compromised Data\" \"Expected Finding: Potential data compromise of one or more S3 buckets involving a sequence of actions associated with User.\" \"Finding Type : AttackSequence:S3/CompromisedData\" \"\"",
+            "local": "false",
+            "logSource": "s3-logs"
+        },
+        {
             "resource": "s3",
             "tactic": "discovery",
             "findingType": "Discovery:S3/MaliciousIPCaller.Custom",

--- a/lib/common/testResources/guardduty_tester.py
+++ b/lib/common/testResources/guardduty_tester.py
@@ -53,7 +53,8 @@ EXAMPLES:
     
     # lists of all resources/tactics available to tester
     resources = [
-        'ec2', 
+        'attack-sequence',
+        'ec2',
         'ecs-ec2',
         'ecs-fargate',
         'eks', 
@@ -62,6 +63,7 @@ EXAMPLES:
         's3'
     ]
     tactics = [
+        'attack-sequence',
         'backdoor',
         'crypto',
         'defense-evasion',

--- a/lib/common/testResources/scenarios/attack/S3CompromisedData.sh
+++ b/lib/common/testResources/scenarios/attack/S3CompromisedData.sh
@@ -1,0 +1,42 @@
+#Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+CREDS=$(aws sts assume-role --role-arn ${TEMP_ROLE_ARN} --role-session-name s3_compromised_data)
+export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $CREDS | jq .Credentials.SessionToken | xargs)
+
+# List users
+aws iam list-users --region $REGION &> /dev/null || true
+
+# List roles
+aws iam list-roles --region $REGION &> /dev/null || true
+
+# List buckets
+aws s3api list-buckets --region $REGION &> /dev/null || true
+
+# List objects
+aws s3api list-objects --bucket "$ATTACK_BUCKET_NAME" --region $REGION &> /dev/null || true
+
+# Put a ransom note object
+RANSOM_NOTE="Test ransom note"
+echo "$RANSOM_NOTE" > ransom_note.txt
+aws s3 cp ransom_note.txt "s3://$ATTACK_BUCKET_NAME/RANSOM_NOTE.txt" --region $REGION &> /dev/null || true
+rm -f ransom_note.txt
+
+# Delete the ransom note object
+aws s3api delete-object --bucket "$ATTACK_BUCKET_NAME" --key "RANSOM_NOTE.txt" --region $REGION &> /dev/null || true
+
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN

--- a/lib/common/testResources/scenarios/iam/KaliLinux.sh
+++ b/lib/common/testResources/scenarios/iam/KaliLinux.sh
@@ -12,8 +12,12 @@
 #  permissions and limitations under the License.
 
 CREDS=$(aws sts assume-role --role-arn ${TEMP_ROLE_ARN} --role-session-name s3_pentest)
-export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq .AccessKeyId | xargs)
-export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq .SecretAccessKey | xargs)
-export AWS_SESSION_TOKEN=$(echo $CREDS | jq .Token | xargs)
+export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $CREDS | jq .Credentials.SessionToken | xargs)
 
 aws iam get-user --region $REGION
+
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN

--- a/lib/common/testResources/scenarios/s3/KaliLinux.sh
+++ b/lib/common/testResources/scenarios/s3/KaliLinux.sh
@@ -12,8 +12,12 @@
 #  permissions and limitations under the License.
 
 CREDS=$(aws sts assume-role --role-arn ${TEMP_ROLE_ARN} --role-session-name s3_pentest)
-export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq .AccessKeyId | xargs)
-export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq .SecretAccessKey | xargs)
-export AWS_SESSION_TOKEN=$(echo $CREDS | jq .Token | xargs)
+export AWS_ACCESS_KEY_ID=$(echo $CREDS | jq .Credentials.AccessKeyId | xargs)
+export AWS_SECRET_ACCESS_KEY=$(echo $CREDS | jq .Credentials.SecretAccessKey | xargs)
+export AWS_SESSION_TOKEN=$(echo $CREDS | jq .Credentials.SessionToken | xargs)
 
 aws s3api list-objects-v2 --region $REGION --bucket $S3_BUCKET_NAME
+
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN

--- a/lib/common/testResources/test_builder.py
+++ b/lib/common/testResources/test_builder.py
@@ -289,6 +289,7 @@ class Tests:
             f'LINUX_INSTANCE=\'{vars.LINUX_INSTANCE}\'',
             f'WINDOWS_INSTANCE=\'{vars.WINDOWS_INSTANCE}\'',
             f'S3_BUCKET_NAME=\'{vars.S3_BUCKET_NAME}\'',
+            f'ATTACK_BUCKET_NAME=\'{vars.ATTACK_BUCKET_NAME}\'',
             f'EMPTY_BUCKET_NAME=\'{vars.EMPTY_BUCKET_NAME}\'',
             f'TEMP_ROLE_ARN=\'{vars.TEMP_ROLE_ARN}\'',
             f'REGION=\'{vars.REGION}\'',

--- a/lib/stacks/tester-stack.ts
+++ b/lib/stacks/tester-stack.ts
@@ -53,6 +53,7 @@ export class GuardDutyTesterStack extends Stack {
 
     const testerBucket = new TesterBucket(this, 'testerBucket');
     const emptyBucket = new EmptyBucket(this, 'emptyBucket');
+    const attackBucket = new EmptyBucket(this, 'attackBucket');
     const testerLambda = new TesterLambda(this, 'testerLambda', {
       accountId: this.account,
       region: this.region,
@@ -128,6 +129,7 @@ export class GuardDutyTesterStack extends Stack {
       tempRole: tempRole.arn,
       stepFuncArn: stepFunction.machineArn,
       emptyBucketName: emptyBucket.bucketName,
+      attackBucketName: attackBucket.bucketName,
       tag: INSTANCE_TAG,
       ec2TaskFamily: EC2_TASK_FAMILY,
       fargateTaskFamily: FARGATE_TASK_FAMILY,


### PR DESCRIPTION
*Issue #, if available:* 
N/A

*Description of changes:*
Adding test for the new [AttackSequence:S3/CompromisedData](https://docs.aws.amazon.com/guardduty/latest/ug/guardduty-attack-sequence-finding-types.html#attack-sequence-s3-compromised-data) finding type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
