### PR TITLE
Fix unsupported EKS Kubernetes version (1.29 -> 1.32)

### DIFF
--- a/lib/common/compute/eks/tester-eks.ts
+++ b/lib/common/compute/eks/tester-eks.ts
@@ -44,7 +44,7 @@ export class TesterEksCluster extends Construct {
     });
 
     this.eks = new Cluster(this, id, {
-      version: KubernetesVersion.of('1.29'),
+      version: KubernetesVersion.of('1.32'),
       defaultCapacity: 0,
       vpc: props.vpc,
       securityGroup: eksSecurityGroup.sg,

--- a/test/__snapshots__/cdk-gd-tester.test.ts.snap
+++ b/test/__snapshots__/cdk-gd-tester.test.ts.snap
@@ -2165,7 +2165,7 @@ echo ECS_AWSVPC_BLOCK_IMDS=true >> /etc/ecs/ecs.config",
               "Arn",
             ],
           },
-          "version": "1.29",
+          "version": "1.32",
         },
         "ServiceToken": {
           "Fn::GetAtt": [


### PR DESCRIPTION
## Summary

Deploying the tester currently fails at EKS cluster creation with an error indicating the Kubernetes version is unsupported:

```
Received response status [FAILED] from custom resource.
Message returned: unsupported Kubernetes version 1.29
```

Kubernetes 1.29 is no longer supported by Amazon EKS, so `CreateCluster` is rejected with an `InvalidParameterException`.

## Change

Bump the cluster version from `1.29` to `1.32` in `lib/common/compute/eks/tester-eks.ts`.

1.32 is chosen deliberately as the least-invasive fix: it is the last Kubernetes version for which Amazon EKS releases Amazon Linux 2 (AL2) optimized AMIs. The node group in this construct uses `NodegroupAmiType.AL2_X86_64`, so staying at 1.32 keeps the existing node group working without requiring an additional switch to AL2023. Moving to 1.33+ would require further changes beyond the reported issue.

## Testing

- `npx tsc` compiles cleanly.
- Updated the CDK snapshot (`test/__snapshots__/cdk-gd-tester.test.ts.snap`) to reflect the new version.
- Note: the full `jest` suite was not run locally because it bundles a Python Lambda asset via Docker, which was unavailable in this environment. The only functional change is the version string.

## Scope

Two lines changed (source + snapshot); no structural or formatting changes.
