### PR TITLE
Fix Lambda bundling on non-Linux Docker hosts (cp -au -> cp -ru)

### DIFF
--- a/lib/common/compute/lambda/cfn-action-lambda.ts
+++ b/lib/common/compute/lambda/cfn-action-lambda.ts
@@ -37,7 +37,7 @@ export class CfnActionLambda extends Construct {
       code: Code.fromAsset(path.join(__dirname, 'cfn_on_event'), {
         bundling: {
           image: Runtime.PYTHON_3_11.bundlingImage,
-          command: ['bash', '-c', 'pip install -r requirements.txt -t /asset-output && cp -au . /asset-output'],
+          command: ['bash', '-c', 'pip install -r requirements.txt -t /asset-output && cp -ru . /asset-output'],
         },
       }),
       timeout: Duration.seconds(900),

--- a/lib/common/compute/lambda/finding-lambda.ts
+++ b/lib/common/compute/lambda/finding-lambda.ts
@@ -38,7 +38,7 @@ export class TesterLambda extends Construct {
       code: Code.fromAsset(path.join(__dirname, 'tester_lambda'), {
         bundling: {
           image: Runtime.PYTHON_3_11.bundlingImage,
-          command: ['bash', '-c', 'pip install -r requirements.txt -t /asset-output && cp -au . /asset-output'],
+          command: ['bash', '-c', 'pip install -r requirements.txt -t /asset-output && cp -ru . /asset-output'],
         },
       }),
       timeout: Duration.seconds(900),

--- a/lib/common/compute/lambda/test-settings-lambda.ts
+++ b/lib/common/compute/lambda/test-settings-lambda.ts
@@ -38,7 +38,7 @@ export class SettingRestorationLambda extends Construct {
       code: Code.fromAsset(path.join(__dirname, 'setting_restore'), {
         bundling: {
           image: Runtime.PYTHON_3_11.bundlingImage,
-          command: ['bash', '-c', 'pip install -r requirements.txt -t /asset-output && cp -au . /asset-output'],
+          command: ['bash', '-c', 'pip install -r requirements.txt -t /asset-output && cp -ru . /asset-output'],
         },
       }),
       timeout: Duration.seconds(900),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Summary

The Lambda asset bundling command uses `cp -au` to copy files into `/asset-output`. The `-a` (archive) flag preserves ownership, timestamps, and extended attributes. When the CDK bundling bind mount is backed by a non-Linux host — for example macOS or Windows using a VM-backed Docker runtime such as colima/Lima (virtiofs) — preserving extended attributes on the mounted directory fails with `ENODATA`:

```
cp: preserving permissions for '/asset-output/.': No data available
Error: docker exited with status 1
```

This blocks `cdk deploy`/`cdk synth` on those hosts. On a native Linux Docker host the bind mount is a real Linux filesystem, so `cp -au` succeeds — which is why this isn't seen everywhere.

## Change

Replace `cp -au` with `cp -ru` in the three Python Lambda constructs:

- `lib/common/compute/lambda/finding-lambda.ts`
- `lib/common/compute/lambda/cfn-action-lambda.ts`
- `lib/common/compute/lambda/test-settings-lambda.ts`

`cp -ru` copies recursively and only updates newer files, but no longer preserves ownership/timestamps/extended attributes. Those attributes are irrelevant for a Lambda deployment package (the content is zipped and extracted by the Lambda runtime; only file contents and read permissions matter). The command runs inside the Linux bundling container in all cases, so this is GNU `cp` regardless of host OS.

## Why this is OS-agnostic

- Linux (native Docker): `cp -au` already worked, and `cp -ru` works too.
- macOS / Windows (VM-backed Docker): `cp -au` failed on extended-attribute preservation, `cp -ru` works.

## Testing

- Verified `cdk synth` bundles all three Lambdas successfully on macOS (colima) and on a native Amazon Linux 2023 EC2 host.
- Verified `cdk deploy` succeeds end-to-end on both.
- `npx tsc` compiles cleanly.

Note: the committed CDK snapshot (`test/__snapshots__/cdk-gd-tester.test.ts.snap`) appears to already be out of date with `master` (it does not reflect several existing resources such as the Ubuntu instance), so this change intentionally leaves the snapshot untouched to keep the diff focused on the bundling fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
