### PR TITLE
Make CloudTrail trail creation optional (deployCloudTrail context flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ AWS credentials staged which have enough permissions for deploying all the resou
 - `cdk bootstrap #if region not bootstrapped previously`
 - `cdk deploy`
 
+> **Note:** The tester creates a dedicated CloudTrail trail to support the `Stealth:IAMUser/CloudTrailLoggingDisabled` test. If your organization blocks the CloudTrail APIs (for example `cloudtrail:CreateTrail`) via a Service Control Policy (SCP), you can skip creating the trail by deploying with `cdk deploy -c deployCloudTrail=false`. With CloudTrail creation disabled you will not be able to test the `Stealth:IAMUser/CloudTrailLoggingDisabled` finding; all other findings are unaffected.
+
 ![Alt text](GuardDutyTester.png)
 
 ## Run Tests

--- a/lib/common/access/iam/driver-role.ts
+++ b/lib/common/access/iam/driver-role.ts
@@ -18,7 +18,7 @@ export interface DriverRoleProps {
   bucketName: string;
   emptyBucketName: string;
   accountId: string;
-  trailArn: string;
+  trailArn?: string;
   lambdaArn: string;
   region: string;
   debianId: string;
@@ -75,12 +75,17 @@ export class DriverRole extends Construct {
               ],
               resources: ['*'], // Selected actions only support the all resources wildcard('*').
             }),
-            new PolicyStatement({
-              sid: 'CloudTrail',
-              effect: Effect.ALLOW,
-              actions: ['cloudtrail:StopLogging'],
-              resources: [props.trailArn],
-            }),
+            // Only granted when a tester CloudTrail trail is created (deployCloudTrail context flag)
+            ...(props.trailArn
+              ? [
+                  new PolicyStatement({
+                    sid: 'CloudTrail',
+                    effect: Effect.ALLOW,
+                    actions: ['cloudtrail:StopLogging'],
+                    resources: [props.trailArn],
+                  }),
+                ]
+              : []),
             new PolicyStatement({
               sid: 'EC2EIPList',
               effect: Effect.ALLOW,

--- a/lib/common/compute/ecs/driver-cluster.ts
+++ b/lib/common/compute/ecs/driver-cluster.ts
@@ -37,7 +37,7 @@ export interface EcsProps extends Ec2Props {
   tempRole: string;
   accountId: string;
   cloudTrailName: string;
-  cloudTrailArn: string;
+  cloudTrailArn?: string;
   lambdaName: string;
   lambdaArn: string;
   eksCluster: string;

--- a/lib/stacks/tester-stack.ts
+++ b/lib/stacks/tester-stack.ts
@@ -61,10 +61,19 @@ export class GuardDutyTesterStack extends Stack {
       accountId: this.account,
       region: this.region,
     });
-    const cloudtrail = new TesterCloudTrail(this, 'testerCloudTrail', {
-      bucket: testerBucket.bucket,
-      name: TRAIL_NAME,
-    });
+    // CloudTrail creation is optional. Some organizations block the CloudTrail APIs
+    // (e.g. cloudtrail:CreateTrail) via an SCP, which would fail deployment. Disable
+    // with `cdk deploy -c deployCloudTrail=false`. When disabled, the
+    // Stealth:IAMUser/CloudTrailLoggingDisabled finding cannot be tested.
+    const cloudTrailContext = this.node.tryGetContext('deployCloudTrail');
+    const deployCloudTrail =
+      cloudTrailContext === undefined || cloudTrailContext === true || cloudTrailContext === 'true';
+    const cloudtrail = deployCloudTrail
+      ? new TesterCloudTrail(this, 'testerCloudTrail', {
+          bucket: testerBucket.bucket,
+          name: TRAIL_NAME,
+        })
+      : undefined;
     const cfnLambda = new CfnActionLambda(this, 'testerCfnLambda', {
       accountId: this.account,
       region: this.region,
@@ -135,8 +144,8 @@ export class GuardDutyTesterStack extends Stack {
       debianRoleName: debianInstance.instanceRole.role.roleName,
       windowsIp: windowsInstance.ec2.instancePrivateIp,
       windowsInstance: windowsInstance.ec2.instanceId,
-      cloudTrailName: TRAIL_NAME,
-      cloudTrailArn: cloudtrail.trailArn,
+      cloudTrailName: deployCloudTrail ? TRAIL_NAME : '',
+      cloudTrailArn: cloudtrail?.trailArn,
       lambdaName: testerLambda.functionName,
       lambdaArn: testerLambda.functionArn,
       ingressSecurityGroup: debianInstance.sgId,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## Summary

The tester always creates a dedicated CloudTrail trail (`GuardDutyTesterCloudTrail`) to support the `Stealth:IAMUser/CloudTrailLoggingDisabled` finding test. In accounts where an AWS Organizations Service Control Policy (SCP) denies the CloudTrail APIs (for example `cloudtrail:CreateTrail`), the stack deployment fails:

```
Resource handler returned message: "Access denied for operation ... cloudtrail:CreateTrail ... with an explicit deny in a service control policy ..."
```

This makes the tester undeployable in those environments, even though only one of the many findings depends on the trail.

## Change

Make trail creation optional via a CDK context flag, `deployCloudTrail`:

- Defaults to `true`, so existing behavior is unchanged.
- Deploy with `cdk deploy -c deployCloudTrail=false` to skip creating the trail.

When disabled:
- The `TesterCloudTrail` construct is not created.
- The driver role no longer requests `cloudtrail:StopLogging` (the grant is conditional on a trail being present).
- `cloudTrailName` is passed as empty, and `cloudTrailArn` is omitted.

The only functional loss is that the `Stealth:IAMUser/CloudTrailLoggingDisabled` finding cannot be tested; all other findings are unaffected.

Files changed:
- `lib/stacks/tester-stack.ts` — gate trail creation behind the flag.
- `lib/common/access/iam/driver-role.ts` — make `trailArn` optional and add the `StopLogging` statement only when a trail exists.
- `lib/common/compute/ecs/driver-cluster.ts` — make `cloudTrailArn` optional.
- `README.md` — document the flag.

Because the flag defaults to `true`, the synthesized template is identical to today's when the flag is not set.

## Testing

- `cdk deploy -c deployCloudTrail=false` deploys successfully in an account whose SCP blocks CloudTrail (previously failed).
- `cdk deploy` (default) still creates the trail and the `StopLogging` grant as before.
- `npx tsc` compiles cleanly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
